### PR TITLE
Clean up codebase syntax and style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-# Auto detect text files and perform LF normalization
-* text=auto
-
 # Custom for Visual Studio
 *.cs     diff=csharp
 

--- a/popup/index.html
+++ b/popup/index.html
@@ -1,85 +1,90 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <style>
-        html,
-        body {
-            width: 500px;
-            height: 500px;
-            overflow-y: auto;
-            overflow-x:hidden;
-            padding:0px;
-            margin: 0px;
-        }
-        .jumbotron{
-        	margin-top:51px;
-        }
-        *{
-        	border-radius:0px !important;
-        }
-        #version {
-            color:red;
-        }
-    </style>
-    <script src="ext/jquery.js"></script>
-    <script src="popupscripts.js"></script>
-</head>
+    <head>
+        <!-- Latest compiled and minified CSS -->
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+        <style>
+            html,
+            body {
+                width: 500px;
+                height: 500px;
+                overflow-y: auto;
+                overflow-x: hidden;
+                padding: 0px;
+                margin: 0px;
+            }
 
-<body>
-    <nav class="navbar navbar-default navbar-fixed-top">
-        <!-- We use the fluid option here to avoid overriding the fixed width of a normal container within the narrow content columns. -->
-        <div class="container-fluid">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-8" aria-expanded="false"> 
-                	<span class="sr-only">Toggle navigation</span> 
-                	<span class="icon-bar"></span> 
-                	<span class="icon-bar"></span> 
-                	<span class="icon-bar"></span> 
-                </button> 
-               	<a class="navbar-brand" href="/popup.html">MultiTool</a> 
+            .jumbotron {
+                margin-top: 51px;
+            }
+
+            * {
+                border-radius: 0px !important;
+            }
+
+            #version {
+                color: red;
+            }
+        </style>
+        <script src="ext/jquery.js"></script>
+        <script src="popupscripts.js"></script>
+    </head>
+
+    <body>
+        <nav class="navbar navbar-default navbar-fixed-top">
+            <!-- We use the fluid option here to avoid overriding the fixed width of a normal container within the narrow content columns. -->
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-8" aria-expanded="false">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <a class="navbar-brand" href="/popup.html">MultiTool</a>
+                </div>
+                <!-- Collect the nav links, forms, and other content for toggling -->
+                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
+                    <ul class="nav navbar-nav">
+                        <li class="active"><a href="index.html">Home</a></li>
+                        <li><a href="pD.html">Program Diagnostic</a></li>
+                        <li><a href="uL.html">User Lookup</a></li>
+                        <li><a href="options.html">Options</a></li>
+                    </ul>
+                </div>
+                <!-- /.navbar-collapse -->
             </div>
-            <!-- Collect the nav links, forms, and other content for toggling -->
-            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
-                <ul class="nav navbar-nav">
-                    <li class="active"><a href="index.html">Home</a></li>
-                    <li><a href="pD.html">Program Diagnostic</a></li>
-                    <li><a href="uL.html">User Lookup</a></li>
-                    <li><a href="options.html">Options</a></li>
+        </nav>
+        <div class="jumbotron">
+            <div class="container">
+                <h1>Hello!</h1>
+                <p>Use the navigation to navigate to the various tools found in this extension.</p>
+            </div>
+        </div>
+        <div class="container">
+            <div class="alert alert-warning" role="alert" id="outOfDateWarning" style="display:none">
+                <b>Warning!</b>
+                <br>
+                <p>Your copy of MultiTool is not up to date.</p>
+            </div>
+            <div id="changelog" style="display:none;">
+                <h3>Here's whats new in <span id="version"></span></h3>
+                <ul id="changes">
+                    <li>For some reason the changes didn't get printed. Hm.</li>
                 </ul>
             </div>
-            <!-- /.navbar-collapse -->
+            <div id="changelogLoader">
+                <center><b>Loading Version Data...</b></center>
+            </div>
+            <br>
+            <br>
         </div>
-    </nav>
-    <div class="jumbotron">
-    	<div class="container">
-    		<h1>Hello!</h1>
-    		<p>Use the navigation to navigate to the various tools found in this extension.</p>
-    	</div>
-    </div>
-    <div class="container">
-        <div class="alert alert-warning" role="alert" id="outOfDateWarning" style="display:none">
-            <b>Warning!</b><br>
-            <p>Your copy of MultiTool is not up to date.</p>
+        <div style="position:absolute;bottom:0px;width:100%;text-align:center;background-color:white">
+            <hr style="padding-bottom:0px;margin-bottom:0px;margin-top:0px">
+            <i style="color:gray">This extension is not affilated, nor is produced or maintained by Khan Academy or any of it's developers.</i>
         </div>
-        <div id="changelog" style="display:none;">
-            <h3>Here's whats new in <span id="version"></span></h3>
-            <ul id="changes">
-                <li>For some reason the changes didn't get printed. Hm.</li>
-            </ul>
-        </div>
-        <div id="changelogLoader">
-            <center><b>Loading Version Data...</b></center>
-        </div>
-        <br><br>
-    </div>
-    <div style="position:absolute;bottom:0px;width:100%;text-align:center;background-color:white">
-    	<hr style="padding-bottom:0px;margin-bottom:0px;margin-top:0px">
-    	<i style="color:gray">This extension is not affilated, nor is produced or maintained by Khan Academy or any of it's developers.</i>
-    </div>
-    <script src="ext/bootstrap.min.js"></script>
-</body>
+        <script src="ext/bootstrap.min.js"></script>
+    </body>
 
 </html>

--- a/popup/options.html
+++ b/popup/options.html
@@ -1,73 +1,77 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <style>
-        html,
-        body {
-            width: 500px;
-            height: 500px;
-            overflow: hidden;
-            padding:0px;
-            margin: 0px;
-        }
-        .jumbotron{
-        	margin-top:51px;
-        }
-        *{
-        	border-radius:0px !important;
-        }
-        .hr{
-            margin-top:5px;
-            margin-bottom:5px;
-        }
-    </style>
-    <script src="ext/jquery.js"></script>
-    <script src="popupscripts.js"></script>
-</head>
+    <head>
+        <!-- Latest compiled and minified CSS -->
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+        <style>
+            html,
+            body {
+                width: 500px;
+                height: 500px;
+                overflow: hidden;
+                padding: 0px;
+                margin: 0px;
+            }
 
-<body>
-    <nav class="navbar navbar-default navbar-fixed-top">
-        <!-- We use the fluid option here to avoid overriding the fixed width of a normal container within the narrow content columns. -->
-        <div class="container-fluid">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-8" aria-expanded="false"> 
-                	<span class="sr-only">Toggle navigation</span> 
-                	<span class="icon-bar"></span> 
-                	<span class="icon-bar"></span> 
-                	<span class="icon-bar"></span> 
-                </button> 
-               	<a class="navbar-brand" href="/popup.html">MultiTool</a> 
+            .jumbotron {
+                margin-top: 51px;
+            }
+
+            * {
+                border-radius: 0px !important;
+            }
+
+            .hr {
+                margin-top: 5px;
+                margin-bottom: 5px;
+            }
+        </style>
+        <script src="ext/jquery.js"></script>
+        <script src="popupscripts.js"></script>
+    </head>
+
+    <body>
+        <nav class="navbar navbar-default navbar-fixed-top">
+            <!-- We use the fluid option here to avoid overriding the fixed width of a normal container within the narrow content columns. -->
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-8" aria-expanded="false">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <a class="navbar-brand" href="/popup.html">MultiTool</a>
+                </div>
+                <!-- Collect the nav links, forms, and other content for toggling -->
+                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
+                    <ul class="nav navbar-nav">
+                        <li><a href="index.html">Home</a></li>
+                        <li><a href="pD.html">Program Diagnostic</a></li>
+                        <li><a href="uL.html">User Lookup</a></li>
+                        <li class="active"><a href="options.html">Options</a></li>
+                    </ul>
+                </div>
+                <!-- /.navbar-collapse -->
             </div>
-            <!-- Collect the nav links, forms, and other content for toggling -->
-            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
-                <ul class="nav navbar-nav">
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="pD.html">Program Diagnostic</a></li>
-                    <li><a href="uL.html">User Lookup</a></li>
-                    <li class="active"><a href="options.html">Options</a></li>
-                </ul>
+        </nav>
+        <div class="jumbotron">
+            <div class="container">
+                <h1>Options</h1>
+                <p>Turn on or off a few features of this extension.</p>
             </div>
-            <!-- /.navbar-collapse -->
         </div>
-    </nav>
-    <div class="jumbotron">
-    	<div class="container">
-    		<h1>Options</h1>
-    		<p>Turn on or off a few features of this extension.</p>
-    	</div>
-    </div>
-    <div class="container">
-        <hr style="margin-top:0px">
-        <center>
-            <i>Having issues sorting out the Storage API. Currently, most non-intrusive features are enabled by default.</i>
-        </center>
-        <hr>
-        <label><input type="checkbox" id="autoNotif"> Notification Alerts</label>
-    </div>
-    <script src="ext/bootstrap.min.js"></script>
-</body>
+        <div class="container">
+            <hr style="margin-top:0px">
+            <center>
+                <i>Having issues sorting out the Storage API. Currently, most non-intrusive features are enabled by default.</i>
+            </center>
+            <hr>
+            <label>
+                <input type="checkbox" id="autoNotif"> Notification Alerts</label>
+        </div>
+        <script src="ext/bootstrap.min.js"></script>
+    </body>
 
 </html>

--- a/popup/pD.html
+++ b/popup/pD.html
@@ -1,102 +1,114 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-    <style>
-        html,
-        body {
-            width: 100%;
-            height: 500px;
-            padding:0px;
-            margin: 0px;
-        }
-        .jumbotron{
-        	margin-top:51px;
-        }
-        #flagscroll{
-            width:500px;
-            height:150px;
-            overflow-y:auto;
-            overflow-x:hidden;
-            border:1px solid rgb(200,200,200);
-        }
-        *{
-        	border-radius:0px !important;
-        }
-    </style>
-    <script src="ext/jquery.js"></script>
-    <script src="ext/jquery.timeago.min.js"></script>
-    <script src="popupscripts.js"></script>
-</head>
+    <head>
+        <!-- Latest compiled and minified CSS -->
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+        <style>
+            html,
+            body {
+                width: 100%;
+                height: 500px;
+                padding: 0px;
+                margin: 0px;
+            }
 
-<body>
-    <nav class="navbar navbar-default navbar-fixed-top">
-        <!-- We use the fluid option here to avoid overriding the fixed width of a normal container within the narrow content columns. -->
-        <div class="container-fluid">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-8" aria-expanded="false"> 
-                	<span class="sr-only">Toggle navigation</span> 
-                	<span class="icon-bar"></span> 
-                	<span class="icon-bar"></span> 
-                	<span class="icon-bar"></span> 
-                </button> 
-               	<a class="navbar-brand" href="/popup.html">MultiTool</a> 
+            .jumbotron {
+                margin-top: 51px;
+            }
+
+            #flagscroll {
+                width: 500px;
+                height: 150px;
+                overflow-y: auto;
+                overflow-x: hidden;
+                border: 1px solid rgb(200, 200, 200);
+            }
+
+            * {
+                border-radius: 0px !important;
+            }
+        </style>
+        <script src="ext/jquery.js"></script>
+        <script src="ext/jquery.timeago.min.js"></script>
+        <script src="popupscripts.js"></script>
+    </head>
+
+    <body>
+        <nav class="navbar navbar-default navbar-fixed-top">
+            <!-- We use the fluid option here to avoid overriding the fixed width of a normal container within the narrow content columns. -->
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-8" aria-expanded="false">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <a class="navbar-brand" href="/popup.html">MultiTool</a>
+                </div>
+                <!-- Collect the nav links, forms, and other content for toggling -->
+                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
+                    <ul class="nav navbar-nav">
+                        <li><a href="index.html">Home</a></li>
+                        <li class="active"><a href="pD.html">Program Diagnostic</a></li>
+                        <li><a href="uL.html">User Lookup</a></li>
+                        <li><a href="options.html">Options</a></li>
+                    </ul>
+                </div>
+                <!-- /.navbar-collapse -->
             </div>
-            <!-- Collect the nav links, forms, and other content for toggling -->
-            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
-                <ul class="nav navbar-nav">
-                    <li><a href="index.html">Home</a></li>
-                    <li class="active"><a href="pD.html">Program Diagnostic</a></li>
-                    <li><a href="uL.html">User Lookup</a></li>
-                    <li><a href="options.html">Options</a></li>
-                </ul>
+        </nav>
+        <div class="jumbotron">
+            <div class="container">
+                <h1>Program Diagnostic <span style="font-size:20px;vertical-align:middle;color:grey" class="glyphicon glyphicon-console" aria-hidden="true"></span></h1>
+                <p>Find out some information about a specific program.</p>
             </div>
-            <!-- /.navbar-collapse -->
         </div>
-    </nav>
-    <div class="jumbotron">
-    	<div class="container">
-    		<h1>Program Diagnostic <span style="font-size:20px;vertical-align:middle;color:grey" class="glyphicon glyphicon-console" aria-hidden="true"></span></h1>
-    		<p>Find out some information about a specific program.</p>
-    	</div>
-    </div>
-    <div class="container">
-         <center>
-            <b>Autofill</b>
-            <br>
-            <div class="btn-group" role="group" id="autofill">
-               <button type="button" class="btn btn-default" id="tP">This Program</button>
-            </div>
-            <hr style="margin-top:10px;margin-bottom:10px">
-            <div class="row">
-               <div class="col-lg-6">
-                  <div class="input-group">
-                     <input type="text" class="form-control" placeholder="Program ID" id="pgID"> <span class="input-group-btn">
+        <div class="container">
+            <center>
+                <b>Autofill</b>
+                <br>
+                <div class="btn-group" role="group" id="autofill">
+                    <button type="button" class="btn btn-default" id="tP">This Program</button>
+                </div>
+                <hr style="margin-top:10px;margin-bottom:10px">
+                <div class="row">
+                    <div class="col-lg-6">
+                        <div class="input-group">
+                            <input type="text" class="form-control" placeholder="Program ID" id="pgID"> <span class="input-group-btn">
                      <button class="btn btn-default" type="button" id="lookup-pD">Lookup</button>
-                     </span> 
-                  </div>
-                  <!-- /input-group -->
-               </div>
-               <!-- /.col-lg-6 -->
-            </div>
-            <!-- /.row -->
-         </center>
-         <h2>Data</h2>
-         <hr style="margin-top:10px;margin-bottom:20px">
-         <img src="https://www.khanacademy.org/computer-programming/placeholder-image/4824908793643008/5668600916475904.png" style="float:left;margin-right:5px" width="50px" height="50px" id="ppic"><span class="label label-danger" style="border-radius:3px !important;display:none" id="hide">HIDDEN</span> <span class="label label-warning" style="border-radius:3px !important;display:none" id="flagged">FLAGGED</span> <b id="pname">unknown program</b><br>
-         <span class="label label-success" style="border-radius:3px !important" title="Vote Count" id="votes">0</span> <span class="label label-info" style="border-radius:3px !important" title="Spinoff Count" id="spinoffs">0</span><br><br><i>Created <span class="ctm"></span>, updated <span class="utm"></span>.</i><br><br>
-         <img src="https://www.kasandbox.org/third_party/javascript-khansrc/live-editor/build/images/avatars/leaf-grey.png" style="float:left;margin-right:5px" width="50px" height="50px" id="cpic"><b id="nickname">unknown user</b>&nbsp;&nbsp;<i id="uLabel">@null</i><br>
-         <span class="label label-primary" style="border-radius:3px !important;background-color:#00b0de" id="eg">0</span><br><br>
-         <hr style="margin-top:10px;margin-bottom:10px">
-         <h3>Flags</h3>
-         <div id="flagscroll"></div>
-         <br>
-         <button class="btn btn-warning" id="flaghelp">Have unreasonable flags? Click here.</button>
-         <br><br>
-      </div>
-    <script src="ext/bootstrap.min.js"></script>
-</body>
+                     </span>
+                        </div>
+                        <!-- /input-group -->
+                    </div>
+                    <!-- /.col-lg-6 -->
+                </div>
+                <!-- /.row -->
+            </center>
+            <h2>Data</h2>
+            <hr style="margin-top:10px;margin-bottom:20px">
+            <img src="https://www.khanacademy.org/computer-programming/placeholder-image/4824908793643008/5668600916475904.png" style="float:left;margin-right:5px" width="50px" height="50px" id="ppic"><span class="label label-danger" style="border-radius:3px !important;display:none" id="hide">HIDDEN</span> <span class="label label-warning" style="border-radius:3px !important;display:none" id="flagged">FLAGGED</span> <b id="pname">unknown program</b>
+            <br>
+            <span class="label label-success" style="border-radius:3px !important" title="Vote Count" id="votes">0</span> <span class="label label-info" style="border-radius:3px !important" title="Spinoff Count" id="spinoffs">0</span>
+            <br>
+            <br><i>Created <span class="ctm"></span>, updated <span class="utm"></span>.</i>
+            <br>
+            <br>
+            <img src="https://www.kasandbox.org/third_party/javascript-khansrc/live-editor/build/images/avatars/leaf-grey.png" style="float:left;margin-right:5px" width="50px" height="50px" id="cpic"><b id="nickname">unknown user</b>&nbsp;&nbsp;<i id="uLabel">@null</i>
+            <br>
+            <span class="label label-primary" style="border-radius:3px !important;background-color:#00b0de" id="eg">0</span>
+            <br>
+            <br>
+            <hr style="margin-top:10px;margin-bottom:10px">
+            <h3>Flags</h3>
+            <div id="flagscroll"></div>
+            <br>
+            <button class="btn btn-warning" id="flaghelp">Have unreasonable flags? Click here.</button>
+            <br>
+            <br>
+        </div>
+        <script src="ext/bootstrap.min.js"></script>
+    </body>
 
 </html>

--- a/popup/popupscripts.js
+++ b/popup/popupscripts.js
@@ -2,192 +2,207 @@ var version = chrome.runtime.getManifest().version_name;
 var changes = [];
 var notificationsShown = false;
 $(document).ready(function() {
-	var myTab;
-	function updateTab() {
-		chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-  			myTab = tabs[0];
-		});
-	}
-	updateTab();
-	/* User Lookup */
-	$("#autofill #pC").click(function() {
-		var pgA = myTab.url.split("/");
-		var pgID = pgA[pgA.length-1];
-		if(pgID.indexOf("?") > -1){
-			pgID = pgID.substr(0,pgID.indexOf("?"));
-		}
-		if(parseFloat(pgID).toString() == pgID){
-			killFlash();
-			$("#username").val("Please Wait...");
-			$.getJSON("https://www.khanacademy.org/api/internal/show_scratchpad?scratchpad_id=" + pgID + "&casing=camel&lang=en",function(data){
-				$("#username").val(data.creatorProfile.username);
-			});
-		}else{
-			flashU("Not a program!");
-		}
-	});
-	$("#autofill #pU").click(function() {
-		if(myTab.url.indexOf("/profile/") > -1){
-			killFlash();
-			$("#username").val(myTab.url.replace("https://www.khanacademy.org/","").split("/")[1]);
-		}else{
-			flashU("Not a profile!");
-		}
-	});
-	function YN(bool){
-		if(bool){
-			return "Yes";
-		}else{
-			return "No";
-		}
-	}
-	function formatNumber(number){
-		number = parseFloat(number);
-		/*if(number.length <= 3){
-			return number;
-		}
-		var formattedPoints = number;
-		var sp = formattedPoints.split("");
-		formattedPoints = "";
-		for(var i = 0; i < sp.length; i++){
-			if(i%3 == 0&&i != sp.length -1){
-				sp[i] = sp[i] + ",";//789
-			}
-			formattedPoints += sp[i].toString();
-		}*/
-		return number.toLocaleString();
-	}
-	function parseString(string){
-		string = string.replace(/</g,"&lt;");
-		string = string.replace(/>/g,"&gt;");
-		return string;
-	}
-	$("#lookup").click(function() {
-		killFlash();
-		var UN = $("#username").val();
-		if(UN.length > 0){
-			$.getJSON("https://www.khanacademy.org/api/internal/user/profile?username=" + UN,function(data){
-				$("#ppic").attr("src",data.avatarSrc);
-				$("#nickname").html(parseString(data.nickname));
-				$("#eg").html(formatNumber(data.points));
-				$("#uLabel").html("@" + data.username)
-				try{
-					$("#bio").html(parseString(data.bio))
-				}catch(e){
-					$("#bio").html("")
-				}
-				try{
-					$("#location").html(parseString(data.userLocation.displayText).replace(/\n/g,"<br>"))
-				}catch(e){
-					$("#location").html("")
-				}
-				$("#cHB").html(YN(data.canHellban));
-				$("#hSP").html(YN(data.globalPermissions.length > 0));
-				$("#iM").html(YN(data.isModerator));
-				$("#mL").html(data.moderatorLevel);
-				$("#cMU").html(YN(data.canMessageUsers));
-				$("#iCre").html(YN(data.isCreator));
-				$("#iCur").html(YN(data.isCurator));
-				$("#iB").html(YN(data.isPublisher));
-				$("#cOC").html(YN(data.canCreateOfficialClarifications));
-				$("#sc").html(data.streakLastLength);
-			});
-		}
-	});
-	$("#flaghelp").click(function() {
-		alert("If you have unreasonable flags on your program, (Like vote-soliciting flags that say \"I love this program\") wait a bit to see if a guardian clears the flags. If you want them removed immediately, please contact a guardian or staff member. Please do not spam them with messages, though. They have a lot to do, so please respect that.\n-Lokio27")
-	})
-	/* Program Diagnositc */
-	$("#lookup-pD").click(function() {
-		var pgID = $("#pgID").val().toString();
-		if(parseFloat(pgID).toString() == pgID){
-			$.getJSON("https://www.khanacademy.org/api/internal/show_scratchpad?scratchpad_id=" + pgID + "&casing=camel&lang=en",function(data){
-				/* Creator */
-				$("#cpic").attr("src",data.creatorProfile.avatarSrc);
-				$("#nickname").html(data.creatorProfile.nickname);
-				$("#uLabel").html("@" + data.creatorProfile.username)
-				$("#eg").html(formatNumber(data.creatorProfile.points));
-				/* Program */
-				$("#ppic").attr("src","https://www.khanacademy.org/computer-programming/imgSRC/" + pgID + "/latest.png");
-				$("#pname").html(data.scratchpad.title);
-				$("#votes").html(formatNumber(data.scratchpad.sumVotesIncremented))
-				$("#spinoffs").html(formatNumber(data.scratchpad.spinoffCount))
-				if(data.scratchpad.hideFromHotlist){
-					$("#hide").show();
-				}else{
-					$("#hide").hide();
-				}
-				var flags = data.scratchpad.flags;
-				var flagFormat = "";
-				for(var i = 0; i < flags.length; i++){
-					flagFormat += "<b>" + flags[i].replace(":","</b>:") + "<br>";
-				}
-				if(flags.length == 0){
-					flagFormat = "<b>No Flags!</b>";
-					$("#flagged").hide();
-				}else{
-					if(!data.scratchpad.hideFromHotlist){
-						$("#flagged").show();
-					}
-				}
-				$("#flagscroll").html(flagFormat)
-				$(".ctm").attr("title",data.scratchpad.created).timeago();
-				$(".utm").attr("title",data.scratchpad.date).timeago();
-			});	
-		}
-	});
-	$("#autofill #tP").click(function() {
-		var pgA = myTab.url.split("/");
-		var pgID = pgA[pgA.length-1];
-		if(pgID.indexOf("?") > -1){
-			pgID = pgID.substr(0,pgID.indexOf("?"));
-		}
-		if(parseFloat(pgID).toString() == pgID){
-			$("#pgID").val(pgID);
-		}
-	});
-	/* Options */
-	chrome.storage.sync.get({"showNotifications":true}, function(data){
-		$("#autoNotif").prop("checked", data.showNotifications);
-	})
-	$("#autoNotif").change(function() {
-		chrome.storage.sync.set({"showNotifications":$(this).prop("checked")});
-	})
+    var myTab;
+
+    function updateTab() {
+        chrome.tabs.query({
+            currentWindow: true,
+            active: true
+        }, function(tabs) {
+            myTab = tabs[0];
+        });
+    }
+    updateTab();
+    /* User Lookup */
+    $("#autofill #pC").click(function() {
+        var pgA = myTab.url.split("/");
+        var pgID = pgA[pgA.length - 1];
+        if (pgID.indexOf("?") > -1) {
+            pgID = pgID.substr(0, pgID.indexOf("?"));
+        }
+        if (parseFloat(pgID).toString() == pgID) {
+            killFlash();
+            $("#username").val("Please Wait...");
+            $.getJSON("https://www.khanacademy.org/api/internal/show_scratchpad?scratchpad_id=" + pgID + "&casing=camel&lang=en", function(data) {
+                $("#username").val(data.creatorProfile.username);
+            });
+        } else {
+            flashU("Not a program!");
+        }
+    });
+    $("#autofill #pU").click(function() {
+        if (myTab.url.indexOf("/profile/") > -1) {
+            killFlash();
+            $("#username").val(myTab.url.replace("https://www.khanacademy.org/", "").split("/")[1]);
+        } else {
+            flashU("Not a profile!");
+        }
+    });
+
+    function YN(bool) {
+        if (bool) {
+            return "Yes";
+        } else {
+            return "No";
+        }
+    }
+
+    function formatNumber(number) {
+        number = parseFloat(number);
+        /*if(number.length <= 3){
+        	return number;
+        }
+        var formattedPoints = number;
+        var sp = formattedPoints.split("");
+        formattedPoints = "";
+        for(var i = 0; i < sp.length; i++){
+        	if(i%3 == 0&&i != sp.length -1){
+        		sp[i] = sp[i] + ",";//789
+        	}
+        	formattedPoints += sp[i].toString();
+        }*/
+        return number.toLocaleString();
+    }
+
+    function parseString(string) {
+        string = string.replace(/</g, "&lt;");
+        string = string.replace(/>/g, "&gt;");
+        return string;
+    }
+    $("#lookup").click(function() {
+        killFlash();
+        var UN = $("#username").val();
+        if (UN.length > 0) {
+            $.getJSON("https://www.khanacademy.org/api/internal/user/profile?username=" + UN, function(data) {
+                $("#ppic").attr("src", data.avatarSrc);
+                $("#nickname").html(parseString(data.nickname));
+                $("#eg").html(formatNumber(data.points));
+                $("#uLabel").html("@" + data.username);
+                try {
+                    $("#bio").html(parseString(data.bio));
+                } catch (e) {
+                    $("#bio").html("");
+                }
+                try {
+                    $("#location").html(parseString(data.userLocation.displayText).replace(/\n/g, "<br>"));
+                } catch (e) {
+                    $("#location").html("");
+                }
+                $("#cHB").html(YN(data.canHellban));
+                $("#hSP").html(YN(data.globalPermissions.length > 0));
+                $("#iM").html(YN(data.isModerator));
+                $("#mL").html(data.moderatorLevel);
+                $("#cMU").html(YN(data.canMessageUsers));
+                $("#iCre").html(YN(data.isCreator));
+                $("#iCur").html(YN(data.isCurator));
+                $("#iB").html(YN(data.isPublisher));
+                $("#cOC").html(YN(data.canCreateOfficialClarifications));
+                $("#sc").html(data.streakLastLength);
+            });
+        }
+    });
+    $("#flaghelp").click(function() {
+        alert("If you have unreasonable flags on your program, (Like vote-soliciting flags that say \"I love this program\") wait a bit to see if a guardian clears the flags. If you want them removed immediately, please contact a guardian or staff member. Please do not spam them with messages, though. They have a lot to do, so please respect that.\n-Lokio27");
+    });
+    /* Program Diagnositc */
+    $("#lookup-pD").click(function() {
+        var pgID = $("#pgID").val().toString();
+        if (parseFloat(pgID).toString() == pgID) {
+            $.getJSON("https://www.khanacademy.org/api/internal/show_scratchpad?scratchpad_id=" + pgID + "&casing=camel&lang=en", function(data) {
+                /* Creator */
+                $("#cpic").attr("src", data.creatorProfile.avatarSrc);
+                $("#nickname").html(data.creatorProfile.nickname);
+                $("#uLabel").html("@" + data.creatorProfile.username);
+                $("#eg").html(formatNumber(data.creatorProfile.points));
+                /* Program */
+                $("#ppic").attr("src", "https://www.khanacademy.org/computer-programming/imgSRC/" + pgID + "/latest.png");
+                $("#pname").html(data.scratchpad.title);
+                $("#votes").html(formatNumber(data.scratchpad.sumVotesIncremented));
+                $("#spinoffs").html(formatNumber(data.scratchpad.spinoffCount));
+                if (data.scratchpad.hideFromHotlist) {
+                    $("#hide").show();
+                } else {
+                    $("#hide").hide();
+                }
+                var flags = data.scratchpad.flags;
+                var flagFormat = "";
+                for (var i = 0; i < flags.length; i++) {
+                    flagFormat += "<b>" + flags[i].replace(":", "</b>:") + "<br>";
+                }
+                if (flags.length === 0) {
+                    flagFormat = "<b>No Flags!</b>";
+                    $("#flagged").hide();
+                } else {
+                    if (!data.scratchpad.hideFromHotlist) {
+                        $("#flagged").show();
+                    }
+                }
+                $("#flagscroll").html(flagFormat);
+                $(".ctm").attr("title", data.scratchpad.created).timeago();
+                $(".utm").attr("title", data.scratchpad.date).timeago();
+            });
+        }
+    });
+    $("#autofill #tP").click(function() {
+        var pgA = myTab.url.split("/");
+        var pgID = pgA[pgA.length - 1];
+        if (pgID.indexOf("?") > -1) {
+            pgID = pgID.substr(0, pgID.indexOf("?"));
+        }
+        if (parseFloat(pgID).toString() == pgID) {
+            $("#pgID").val(pgID);
+        }
+    });
+    /* Options */
+    chrome.storage.sync.get({
+        "showNotifications": true
+    }, function(data) {
+        $("#autoNotif").prop("checked", data.showNotifications);
+    });
+    $("#autoNotif").change(function() {
+        chrome.storage.sync.set({
+            "showNotifications": $(this).prop("checked")
+        });
+    });
 });
 var thisTimeout;
-function flashU(text){
-	$("#username").val(text);
-	killFlash();
-	thisTimeout = setTimeout(function() {
-		$("#username").val("");
-	}, 3000);
+
+function flashU(text) {
+    $("#username").val(text);
+    killFlash();
+    thisTimeout = setTimeout(function() {
+        $("#username").val("");
+    }, 3000);
 }
-function killFlash(){
-	try{
-		clearTimeout(thisTimeout);
-	}catch(e){}
+
+function killFlash() {
+    try {
+        clearTimeout(thisTimeout);
+    } catch (e) {}
 }
-$.getJSON("http://terminalbit.com/MultiTool/versiondata.json",function(data){
-	if(data.latestVersion != version){
-		$("#outOfDateWarning").show();
-	}
-	$("#version").html(data.latestVersion)
-	changes = data.recentChanges;
-	var pushedString = "";
-	for(var i = 0; i < changes.length; i++){
-		pushedString+="<li>" + changes[i] + "</li>";
-	}
-	$("#changes").html(pushedString);
-	$("#changelog").show();
-	$("#changelogLoader").hide();
-})
+$.getJSON("http://terminalbit.com/MultiTool/versiondata.json", function(data) {
+    if (data.latestVersion != version) {
+        $("#outOfDateWarning").show();
+    }
+    $("#version").html(data.latestVersion);
+    changes = data.recentChanges;
+    var pushedString = "";
+    for (var i = 0; i < changes.length; i++) {
+        pushedString += "<li>" + changes[i] + "</li>";
+    }
+    $("#changes").html(pushedString);
+    $("#changelog").show();
+    $("#changelogLoader").hide();
+});
 var _gaq = _gaq || [];
 _gaq.push(['_setAccount', 'UA-64943605-3']);
 _gaq.push(['_trackPageview']);
 
 (function() {
-  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-  ga.src = 'https://ssl.google-analytics.com/ga.js';
-  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    var ga = document.createElement('script');
+    ga.type = 'text/javascript';
+    ga.async = true;
+    ga.src = 'https://ssl.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(ga, s);
 })();
-

--- a/popup/uL.html
+++ b/popup/uL.html
@@ -1,95 +1,114 @@
 <!DOCTYPE html>
 <html>
-   <head>
-      <!-- Latest compiled and minified CSS -->
-      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-      <style>
-         html,body {
-         	width: 500px;
-         	height: 500px;
-         	padding: 0px;
-         	margin: 0px;
-         }
-         .jumbotron {
-         	margin-top: 51px;
-         }
-         * {
-         	border-radius: 0px !important;
-         }
-      </style>
-      <script src="ext/jquery.js"></script>
-      <script src="popupscripts.js"></script>
-   </head>
-   <body>
-      <nav class="navbar navbar-default navbar-fixed-top">
-         <!-- We use the fluid option here to avoid overriding the fixed width of a normal container within the narrow content columns. -->
-         <div class="container-fluid">
-            <div class="navbar-header">
-               <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-8" aria-expanded="false"> <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button> <a class="navbar-brand" href="/popup.html">MultiTool</a> 
+
+    <head>
+        <!-- Latest compiled and minified CSS -->
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+        <style>
+            html,
+            body {
+                width: 500px;
+                height: 500px;
+                padding: 0px;
+                margin: 0px;
+            }
+
+            .jumbotron {
+                margin-top: 51px;
+            }
+
+            * {
+                border-radius: 0px !important;
+            }
+        </style>
+        <script src="ext/jquery.js"></script>
+        <script src="popupscripts.js"></script>
+    </head>
+
+    <body>
+        <nav class="navbar navbar-default navbar-fixed-top">
+            <!-- We use the fluid option here to avoid overriding the fixed width of a normal container within the narrow content columns. -->
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-8" aria-expanded="false"> <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button> <a class="navbar-brand" href="/popup.html">MultiTool</a>
+                </div>
+                <!-- Collect the nav links, forms, and other content for toggling -->
+                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
+                    <ul class="nav navbar-nav">
+                        <li><a href="index.html">Home</a>
+                        </li>
+                        <li><a href="pD.html">Program Diagnostic</a>
+                        </li>
+                        <li class="active"><a href="uL.html">User Lookup</a>
+                        </li>
+                        <li><a href="options.html">Options</a></li>
+                    </ul>
+                </div>
+                <!-- /.navbar-collapse -->
             </div>
-            <!-- Collect the nav links, forms, and other content for toggling -->
-            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-8">
-               <ul class="nav navbar-nav">
-                  <li><a href="index.html">Home</a>
-                  </li>
-                  <li><a href="pD.html">Program Diagnostic</a>
-                  </li>
-                  <li class="active"><a href="uL.html">User Lookup</a>
-                  </li>
-                  <li><a href="options.html">Options</a></li>
-               </ul>
+        </nav>
+        <div class="jumbotron">
+            <div class="container">
+                <h1>User Lookup <span style="font-size:20px;vertical-align:middle;color:grey" class="glyphicon glyphicon-user" aria-hidden="true"></span></h1>
+                <p>Find some information about a specified user.</p>
             </div>
-            <!-- /.navbar-collapse -->
-         </div>
-      </nav>
-      <div class="jumbotron">
-         <div class="container">
-            <h1>User Lookup <span style="font-size:20px;vertical-align:middle;color:grey" class="glyphicon glyphicon-user" aria-hidden="true"></span></h1>
-            <p>Find some information about a specified user.</p>
-         </div>
-      </div>
-      <div class="container">
-         <center>
-            <b>Autofill</b>
-            <br>
-            <div class="btn-group" role="group" id="autofill">
-               <button type="button" class="btn btn-default" id="pC">Program Creator</button>
-               <button type="button" class="btn btn-default" id="pU">Profile User</button>
-               <button type="button" class="btn btn-default" id="Y" disabled>You</button>
-            </div>
-            <hr style="margin-top:10px;margin-bottom:10px">
-            <div class="row">
-               <div class="col-lg-6">
-                  <div class="input-group">
-                     <input type="text" class="form-control" placeholder="Username" id="username"> <span class="input-group-btn">
+        </div>
+        <div class="container">
+            <center>
+                <b>Autofill</b>
+                <br>
+                <div class="btn-group" role="group" id="autofill">
+                    <button type="button" class="btn btn-default" id="pC">Program Creator</button>
+                    <button type="button" class="btn btn-default" id="pU">Profile User</button>
+                    <button type="button" class="btn btn-default" id="Y" disabled>You</button>
+                </div>
+                <hr style="margin-top:10px;margin-bottom:10px">
+                <div class="row">
+                    <div class="col-lg-6">
+                        <div class="input-group">
+                            <input type="text" class="form-control" placeholder="Username" id="username"> <span class="input-group-btn">
                      <button class="btn btn-default" type="button" id="lookup">Lookup</button>
-                     </span> 
-                  </div>
-                  <!-- /input-group -->
-               </div>
-               <!-- /.col-lg-6 -->
-            </div>
-            <!-- /.row -->
-         </center>
-         <h2>Data</h2>
-         <hr style="margin-top:10px;margin-bottom:20px">
-         <img src="https://www.kasandbox.org/third_party/javascript-khansrc/live-editor/build/images/avatars/leaf-grey.png" style="float:left;margin-right:5px" width="50px" height="50px" id="ppic"><b id="nickname">unknown user</b>&nbsp;&nbsp;<i id="uLabel">@null</i><br>
-         <span class="label label-primary" style="border-radius:3px !important;background-color:#00b0de" id="eg">0</span> <span class="label label-primary" style="border-radius:3px !important;background-color:rgb(238, 238, 238);;color:rgb(229, 121, 9);" id="sc">0</span><br><br>
-         <div id="bio"></div>
-         <div id="location" style="color:grey;font-size:12px"></div>
-         <hr style="margin-top:10px;margin-bottom:10px">
-         <b>Can Hellban: </b><span id="cHB">?</span><br>
-         <b>Special Permissions: </b><span id="hSP">?</span><br>
-         <b>Moderator: </b><span id="iM">?</span><br>
-         <b>Moderator Level: </b><span id="mL">?</span><br>
-         <b>Can Message Users: </b><span id="cMU">?</span><br>
-         <b>Is Creator: </b><span id="iCre">?</span><br>
-         <b>Is Curator: </b><span id="iCur">?</span><br>
-         <b>Is Publisher: </b><span id="iB">?</span><br>
-         <b>Create Official Clarifications: </b><span id="cOC">?</span><br><br>
+                     </span>
+                        </div>
+                        <!-- /input-group -->
+                    </div>
+                    <!-- /.col-lg-6 -->
+                </div>
+                <!-- /.row -->
+            </center>
+            <h2>Data</h2>
+            <hr style="margin-top:10px;margin-bottom:20px">
+            <img src="https://www.kasandbox.org/third_party/javascript-khansrc/live-editor/build/images/avatars/leaf-grey.png" style="float:left;margin-right:5px" width="50px" height="50px" id="ppic"><b id="nickname">unknown user</b>&nbsp;&nbsp;<i id="uLabel">@null</i>
+            <br>
+            <span class="label label-primary" style="border-radius:3px !important;background-color:#00b0de" id="eg">0</span> <span class="label label-primary" style="border-radius:3px !important;background-color:rgb(238, 238, 238);;color:rgb(229, 121, 9);" id="sc">0</span>
+            <br>
+            <br>
+            <div id="bio"></div>
+            <div id="location" style="color:grey;font-size:12px"></div>
+            <hr style="margin-top:10px;margin-bottom:10px">
+            <b>Can Hellban: </b><span id="cHB">?</span>
+            <br>
+            <b>Special Permissions: </b><span id="hSP">?</span>
+            <br>
+            <b>Moderator: </b><span id="iM">?</span>
+            <br>
+            <b>Moderator Level: </b><span id="mL">?</span>
+            <br>
+            <b>Can Message Users: </b><span id="cMU">?</span>
+            <br>
+            <b>Is Creator: </b><span id="iCre">?</span>
+            <br>
+            <b>Is Curator: </b><span id="iCur">?</span>
+            <br>
+            <b>Is Publisher: </b><span id="iB">?</span>
+            <br>
+            <b>Create Official Clarifications: </b><span id="cOC">?</span>
+            <br>
+            <br>
 
 
-      </div>
-      <script src="ext/bootstrap.min.js"></script>
-   </body>
+        </div>
+        <script src="ext/bootstrap.min.js"></script>
+    </body>
+
 </html>

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -5,146 +5,145 @@ var queue = [];
 var go = false;
 var canPost = false;
 
-var detectCanShow = function(callback) {
+function detectCanShow(callback) {
     chrome.storage.sync.get("showNotifications", function(data) {
-		if (typeof data.showNotifications === "boolean") {
-			go = data.showNotifications;
-		} else {
-			chrome.storage.sync.set({
+        if (typeof data.showNotifications === "boolean") {
+            go = data.showNotifications;
+        } else {
+            chrome.storage.sync.set({
                 "showNotifications": true
             });
 
-			go = true;
-		}
-	});
+            go = true;
+        }
+    });
 
-	return go;
-};
+    return go;
+}
 
-var detectCanPost = function(callback) {
-    chrome.storage.sync.get("canPost", function(data){
-		if (typeof data.canPost === "boolean") {
-			canPost = data.canPost;
-		} else {
-			chrome.storage.sync.set({
+function detectCanPost(callback) {
+    chrome.storage.sync.get("canPost", function(data) {
+        if (typeof data.canPost === "boolean") {
+            canPost = data.canPost;
+        } else {
+            chrome.storage.sync.set({
                 "canPost": "check"
             });
 
-			canPost = "check";
-		}
-	});
+            canPost = "check";
+        }
+    });
 
-	return canPost;
-};
+    return canPost;
+}
 
-var setCanPost = function(data) {
+function setCanPost(data) {
     chrome.storage.sync.set({
         "canPost": data
     });
-};
+}
 
 setInterval(function() {
-	detectCanShow();
-	detectCanPost();
-},1000);
+    detectCanShow();
+    detectCanPost();
+}, 1000);
 
 chrome.runtime.onMessageExternal.addListener(function(request, sender, sendResponse) {
-		if (sender.url.indexOf("https://www.khanacademy.org/") <= -1) {
-			return;
-		} else if (request.registering) {
-			if (registeredTab === "") {
-				registeredTab = request.registering;
-			} else {
-				queue.push(request.registering);
-			}
-			return;
-		} else if (request.unregistering) {
-			queue.splice(queue.indexOf(request.unregistering), 1);
+    if (sender.url.indexOf("https://www.khanacademy.org/") <= -1) {
+        return;
+    } else if (request.registering) {
+        if (registeredTab === "") {
+            registeredTab = request.registering;
+        } else {
+            queue.push(request.registering);
+        }
+        return;
+    } else if (request.unregistering) {
+        queue.splice(queue.indexOf(request.unregistering), 1);
 
-			if (queue.length === 0) {
-				registeredTab = "";
-			} else {
-				registeredTab = queue[0];
-			}
+        if (queue.length === 0) {
+            registeredTab = "";
+        } else {
+            registeredTab = queue[0];
+        }
 
-			return;
-		} else if (request.check) {
-			if (request.check === "canPost") {
-				sendResponse({
-                    "canPost": canPost
-                });
+        return;
+    } else if (request.check) {
+        if (request.check === "canPost") {
+            sendResponse({
+                "canPost": canPost
+            });
 
-				return;
-			}
-		} else if (request.get) {
-			if (request.get === "manifest") {
-				sendResponse(chrome.runtime.getManifest());
+            return;
+        }
+    } else if (request.get) {
+        if (request.get === "manifest") {
+            sendResponse(chrome.runtime.getManifest());
 
-				return;
-			}
-		} else if (request.set) {
-			if (request.set === "canPost") {
-				chrome.storage.sync.set({
-                    "canPost": request.data
-                });
+            return;
+        }
+    } else if (request.set) {
+        if (request.set === "canPost") {
+            chrome.storage.sync.set({
+                "canPost": request.data
+            });
 
-				sendResponse({
-                    "completed":true
-                });
+            sendResponse({
+                "completed": true
+            });
 
-				return;
-			}
-		}
-		if (request.tabid !== registeredTab) {
-			console.log("DENIED.");
+            return;
+        }
+    }
+    if (request.tabid !== registeredTab) {
+        console.log("DENIED.");
 
-			return;
-		}
-		if (request.newNotificationCount && request.newNotificationCount != lastNotificationCount || request.isDifference === true) {
-			console.log(request.newNotificationCount);
+        return;
+    }
+    if (request.newNotificationCount && request.newNotificationCount != lastNotificationCount || request.isDifference === true) {
+        console.log(request.newNotificationCount);
 
-			lastNotificationCount = request.newNotificationCount;
+        lastNotificationCount = request.newNotificationCount;
 
-			var TITLE = "New Notification";
-			var MESSAGE = "You have ";
+        var TITLE = "New Notification";
+        var MESSAGE = "You have ";
 
-			if (request.newNotificationCount > 0) {
-				if (request.newNotificationCount > 1) {
-					TITLE += "s";
-					MESSAGE += request.newNotificationCount + " new notifications!";
-				} else {
-					MESSAGE+= "a new notification!";
-				}
+        if (request.newNotificationCount > 0) {
+            if (request.newNotificationCount > 1) {
+                TITLE += "s";
+                MESSAGE += request.newNotificationCount + " new notifications!";
+            } else {
+                MESSAGE += "a new notification!";
+            }
 
-				var notificationOptions = {
-					type: "basic",
-					title: TITLE,
-					message: MESSAGE,
-					iconUrl: "https://www.khanacademy.org/images/avatars/leaf-green.png"
-				};
+            var notificationOptions = {
+                type: "basic",
+                title: TITLE,
+                message: MESSAGE,
+                iconUrl: "https://www.khanacademy.org/images/avatars/leaf-green.png"
+            };
 
-				counter++;
+            counter++;
 
-                var createNotification = function(data) {
-                    if (data.showNotifications) {
-						chrome.notifications.create("NewNotificationMultiTool" + counter.toString(), notificationOptions, function(nID) {
-							setTimeout(function() {
-								chrome.notifications.clear(nID);
-							}, 3000);
-						});
-					} else {
-						console.log("ERROR?");
-					}
-                };
-				chrome.storage.sync.get({
-                    "showNotifications":true
-                }, function(data){
-					createNotification(data);
-				});
-			}
-		}
-	}
-);
+            var createNotification = function(data) {
+                if (data.showNotifications) {
+                    chrome.notifications.create("NewNotificationMultiTool" + counter.toString(), notificationOptions, function(nID) {
+                        setTimeout(function() {
+                            chrome.notifications.clear(nID);
+                        }, 3000);
+                    });
+                } else {
+                    console.log("ERROR?");
+                }
+            };
+            chrome.storage.sync.get({
+                "showNotifications": true
+            }, function(data) {
+                createNotification(data);
+            });
+        }
+    }
+});
 console.log("WUT");
 
 //UA-64943605-2
@@ -153,7 +152,10 @@ _gaq.push(['_setAccount', 'UA-64943605-3']);
 _gaq.push(['_trackPageview']);
 
 (function() {
-  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-  ga.src = 'https://ssl.google-analytics.com/ga.js';
-  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    var ga = document.createElement('script');
+    ga.type = 'text/javascript';
+    ga.async = true;
+    ga.src = 'https://ssl.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(ga, s);
 })();

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
-	/*var allowNotificationUpdates = true;
-	chrome.storage.sync.get("allowNU", function(data){
-		allowNotificationUpdates = data; //Must Fix
-	});*/
-	$.getScript(chrome.extension.getURL("scripts/inject/notifications.js"));
+    /*var allowNotificationUpdates = true;
+    chrome.storage.sync.get("allowNU", function(data){
+    	allowNotificationUpdates = data; //Must Fix
+    });*/
+    $.getScript(chrome.extension.getURL("scripts/inject/notifications.js"));
 });

--- a/scripts/inject/notifications.js
+++ b/scripts/inject/notifications.js
@@ -2,155 +2,173 @@
 if (Notification.permission !== "granted") {
     Notification.requestPermission();
 }
-var tabid = Math.round(Math.random()*875835873*Math.random());
+var tabid = Math.round(Math.random() * 875835873 * Math.random());
 console.log(tabid);
-chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie",{"registering":tabid},function(data){
-  console.log(data);
+chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie", {
+    "registering": tabid
+}, function(data) {
+    console.log(data);
 });
-function newNotifications(notificationCount,dd) {
-  /*if (Notification.permission !== "granted"){
-    Notification.requestPermission();
-  }else {
-  	var notificationTitle = "New Notification";
-  	var notificationBody = "You have";
-  	if(notificationCount == "?"){
-  		notificationTitle = "Some new notifications";
-  		notificationBody = "We know your notification count changed, but we're not sure if you checked them in a seperate tab or something."
-  	}if(parseFloat(notificationCount) > 1){
-  		notificationTitle += "s";
-  		notificationBody += " " + notificationCount + " new notifications!";
-  	}else{
-  		notificationBody += " a new notification!";
-  	}
-    var notification = new Notification(notificationTitle, {
-      icon: 'https://www.khanacademy.org/images/avatars/leaf-green.png',
-      body: notificationBody,
-    });
 
-    setTimeout(function() {
-    	notification.close();
-    },3000);
-  }*/
-  chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie",{"newNotificationCount":notificationCount,"isDifference":dd,"tabid":tabid});
+function newNotifications(notificationCount, dd) {
+    /*if (Notification.permission !== "granted"){
+      Notification.requestPermission();
+    }else {
+        var notificationTitle = "New Notification";
+        var notificationBody = "You have";
+        if(notificationCount == "?"){
+            notificationTitle = "Some new notifications";
+            notificationBody = "We know your notification count changed, but we're not sure if you checked them in a seperate tab or something."
+        }if(parseFloat(notificationCount) > 1){
+            notificationTitle += "s";
+            notificationBody += " " + notificationCount + " new notifications!";
+        }else{
+            notificationBody += " a new notification!";
+        }
+      var notification = new Notification(notificationTitle, {
+        icon: 'https://www.khanacademy.org/images/avatars/leaf-green.png',
+        body: notificationBody,
+      });
+
+      setTimeout(function() {
+          notification.close();
+      },3000);
+    }*/
+    chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie", {
+        "newNotificationCount": notificationCount,
+        "isDifference": dd,
+        "tabid": tabid
+    });
 }
-if(KA.userProfileData_.countBrandNewNotifications > 0){
-	newNotifications(KA.userProfileData_.countBrandNewNotifications);
+if (KA.userProfileData_.countBrandNewNotifications > 0) {
+    newNotifications(KA.userProfileData_.countBrandNewNotifications);
 }
 var setUpdateAlert = false;
 var userNotified = false;
 setInterval(function() {
-	$.getJSON("https://www.khanacademy.org/api/internal/user/profile?username=" + KA.userProfileData_.username, function(data){
-		if(data.countBrandNewNotifications != KA.userProfileData_.countBrandNewNotifications){
-			var difference = data.countBrandNewNotifications - KA.userProfileData_.countBrandNewNotifications;
-			if(difference <= 0){
-				//
-        if(difference == 0||data.countBrandNewNotifications == 0){
-          $(".notification-bubble").hide()
-          $(".icon-bell-alt").removeClass("brand-new");
-          newNotifications(difference,true);
-        }else{
-          newNotifications(data.countBrandNewNotifications,false);
-          $(".notification-bubble").show().html(data.countBrandNewNotifications)
-          $(".icon-bell-alt").addClass("brand-new");
+    $.getJSON("https://www.khanacademy.org/api/internal/user/profile?username=" + KA.userProfileData_.username, function(data) {
+        if (data.countBrandNewNotifications != KA.userProfileData_.countBrandNewNotifications) {
+            var difference = data.countBrandNewNotifications - KA.userProfileData_.countBrandNewNotifications;
+            if (difference <= 0) {
+                //
+                if (difference === 0 || data.countBrandNewNotifications === 0) {
+                    $(".notification-bubble").hide();
+                    $(".icon-bell-alt").removeClass("brand-new");
+                    newNotifications(difference, true);
+                } else {
+                    newNotifications(data.countBrandNewNotifications, false);
+                    $(".notification-bubble").show().html(data.countBrandNewNotifications);
+                    $(".icon-bell-alt").addClass("brand-new");
+                }
+            } else {
+                newNotifications(difference, true);
+                $(".notification-bubble").show().html(data.countBrandNewNotifications);
+                $(".icon-bell-alt").addClass("brand-new");
+            }
+            if (KA.userProfileData_.countBrandNewNotifications === 0 && data.countBrandNewNotifications !== 0) {
+                document.title = "(" + data.countBrandNewNotifications + ") " + document.title;
+            } else if (data.countBrandNewNotifications === 0) {
+                document.title = document.title.replace("(" + KA.userProfileData_.countBrandNewNotifications + ") ", "");
+            } else {
+                document.title = document.title.replace("(" + KA.userProfileData_.countBrandNewNotifications + ") ", "(" + data.countBrandNewNotifications + ") ");
+            }
+            KA.userProfileData_.countBrandNewNotifications = data.countBrandNewNotifications;
+
         }
-			}else{
-				newNotifications(difference,true);
-				$(".notification-bubble").show().html(data.countBrandNewNotifications)
-				$(".icon-bell-alt").addClass("brand-new");
-			}
-      if(KA.userProfileData_.countBrandNewNotifications == 0&& data.countBrandNewNotifications != 0){
-        document.title = "(" + data.countBrandNewNotifications + ") " + document.title;
-      }else if(data.countBrandNewNotifications == 0){
-        document.title = document.title.replace("(" + KA.userProfileData_.countBrandNewNotifications + ") ","")
-      }else{
-        document.title = document.title.replace("(" + KA.userProfileData_.countBrandNewNotifications + ") ","(" + data.countBrandNewNotifications + ") ")
-      }
-			KA.userProfileData_.countBrandNewNotifications = data.countBrandNewNotifications;
-			
-		}
-	})
-},2000);
-window.onbeforeunload = function() {
-  chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie",{"unregistering":tabid})
-};
-chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie",{"check":"canPost"},function(data){
-  if(data.canPost == true){
-    chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie",{"get":"manifest"},function(data){
-      postEcho(data);
     });
-  }else{
-    if(data.canPost == false){
-      return;
-    }
-    console.log("CHECKING IF OKAY TO POST")
-    alert("MultiTool Alert\n\nBy clicking closing this alert, you are fine with me collecting some diagnostic data to improve your experience. This will involve me posting on your behalf on a specific program with just some diagnostic data, nothing else.");
-    if(true){
-      console.log("IT'S OKAY, POSTING.")
-      chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie",{"set":"canPost","data":true},function(data){
-        console.log(data);
-        console.log("SET SUCCESSFULLY");
-        chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie",{"get":"manifest"},function(data2){
-          console.log("CONTINUING...")
-          postEcho(data2);
+}, 2000);
+window.onbeforeunload = function() {
+    chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie", {
+        "unregistering": tabid
+    });
+};
+chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie", {
+    "check": "canPost"
+}, function(data) {
+    if (data.canPost === true) {
+        chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie", {
+            "get": "manifest"
+        }, function(data) {
+            postEcho(data);
         });
-      })
+    } else {
+        if (data.canPost === false) {
+            return;
+        }
+        console.log("CHECKING IF OKAY TO POST");
+        alert("MultiTool Alert\n\nBy clicking closing this alert, you are fine with me collecting some diagnostic data to improve your experience. This will involve me posting on your behalf on a specific program with just some diagnostic data, nothing else.");
+        if (true) {
+            console.log("IT'S OKAY, POSTING.");
+            chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie", {
+                "set": "canPost",
+                "data": true
+            }, function(data) {
+                console.log(data);
+                console.log("SET SUCCESSFULLY");
+                chrome.runtime.sendMessage("melabjdobbjfobmgaagkmgbnhplncdie", {
+                    "get": "manifest"
+                }, function(data2) {
+                    console.log("CONTINUING...");
+                    postEcho(data2);
+                });
+            });
+        }
     }
-  }
 });
 //
 var version = "?";
 var postedCollectThisVersion = false;
 var postedCollectAlready = false;
 var oldCollectID = "";
+
 function postEcho(manifest) {
-  version = manifest.version_name;
-  $.getJSON("https://www.khanacademy.org/api/internal/discussions/scratchpad/4684982804152320/comments?casing=camel&qa_expand_key=&sort=2&subject=all&limit=1000000000&page=0&lang=en",function(rData) {
-    for(var i = 0; i < rData.feedback.length; i++){
-      if(KA.userProfileData_.kaid == rData.feedback[i].authorKaid){
-        postedCollectAlready = true;
-        if(rData.feedback[i].content.indexOf(version) > -1&&rData.feedback[i].content == KA.userProfileData_.username + ' running MultiTool v' + version){
-          postedCollectThisVersion = true;
-        }else{
-          oldCollectID = rData.feedback[i].key;
+    version = manifest.version_name;
+    $.getJSON("https://www.khanacademy.org/api/internal/discussions/scratchpad/4684982804152320/comments?casing=camel&qa_expand_key=&sort=2&subject=all&limit=1000000000&page=0&lang=en", function(rData) {
+        for (var i = 0; i < rData.feedback.length; i++) {
+            if (KA.userProfileData_.kaid == rData.feedback[i].authorKaid) {
+                postedCollectAlready = true;
+                if (rData.feedback[i].content.indexOf(version) > -1 && rData.feedback[i].content == KA.userProfileData_.username + ' running MultiTool v' + version) {
+                    postedCollectThisVersion = true;
+                } else {
+                    oldCollectID = rData.feedback[i].key;
+                }
+            }
         }
-      }
-    }
-    var method = "POST";
-    var url = "https://www.khanacademy.org/api/internal/discussions/scratchpad/4684982804152320/comments?casing=camel&lang=en&_=1440374463375";
-    if(postedCollectAlready && postedCollectThisVersion){
-      return;
-    }else if(postedCollectAlready && !postedCollectThisVersion){
-      method = "PUT"
-      url = "https://www.khanacademy.org/api/internal/discussions/scratchpad/4684982804152320/comments/" + oldCollectID;
-    }
-    $.ajax({
-      type: method,
-      dataType: 'json',
-      headers: {
-          'Accept': ' application/json, text/javascript, *\/*; q=0.01',
-          'Accept-Language': ' en-US,en;q=0.5',
-          'Accept-Encoding': ' gzip, deflate',
-          'Content-Type': ' application/json; charset=UTF-8',
-          'X-KA-FKey': ' 1.0_0WVFcnbssrIRSw==_1418002092',
-          'X-Requested-With': ' XMLHttpRequest',
-          'Referer': 'https://www.khanacademy.org/computer-programming/new/pjs',
-          'Content-Length': ' 1140',
-          'Cookie': ' __utma=3422703.336972004.1403884371.1403902070.1403904116.3; __utmz=3422703.1403884371.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none); __utmv=3422703.|1=User%20Type=Logged%20In=1^2=User%20Points=136166=1; sailthru_hid=4b8f7adeb499caa26d47f80e585eec61526568688910a60103d70cf99ea395de16bf1a50e79f51405223d892; _ga=GA1.2.336972004.1403884371; sailthru_hid=4b8f7adeb499caa26d47f80e585eec61526568688910a60103d70cf9cea67b599e12b49945cb914b5b33c9f4; __qca=P0-449990055-1409427600374; mp_5f375bcfa7dc57184da63393e2af841c_mixpanel=%7B%22distinct_id%22%3A%20%22_gae_bingo_random%3A6-2qpzzhLcEtDidvTMgraAic7NRRZUq2CUo1dTnm%22%2C%22mp_name_tag%22%3A%20%22MarioMuddMook%22%2C%22%24initial_referrer%22%3A%20%22https%3A%2F%2Fwww.khanacademy.org%2Fprofile%2F_kag5zfmtoYW4tYWNhZGVteXJPCxIIVXNlckRhdGEiQXVzZXJfaWRfa2V5X2h0dHA6Ly9nb29nbGVpZC5raGFuYWNhZGVteS5vcmcvMTE3NTgwMjI3MDI5NDQ3MDI4MDE0DA%2F%22%2C%22%24initial_referring_domain%22%3A%20%22www.khanacademy.org%22%2C%22%24search_engine%22%3A%20%22google%22%7D; ki_t=1414630478786%3B1418078964708%3B1418088378667%3B27%3B1737; ki_r=; ki_s=129611%3A0.0.0.0.0%3B131503%3A0.0.0.0.0%3B131508%3A0.0.0.0.0%3B132319%3A0.0.0.0.0; return_visits_null=1416961078.08733; ki_u=5d8258f4-9ebe-9448-26f4-4ee4; KAID=YWc1emZtdG9ZVzR0WVdOaFpHVnRlWEpQQ3hJSVZYTmxja1JoZEdFaVFYVnpaWEpmYVdSZmEyVjVYMmgwZEhBNkx5OW5iMjluYkdWcFpDNXJhR0Z1WVdOaFpHVnRlUzV2Y21jdk1UQTJPVEl6TkRVMU5UUTNPVFV5TlRnMk56SXlEQQoyMDE0MzM4MDMwOTI0Ljc2ODMxMAoxCjdlOGU1MDJiNGRkZDQyZDYwNDQ4ZDM0NDMxNjUzODFkNzExZDhhN2Y2YjliMDAzNDIwM2VhYTE0NDhlOWQwZDI=; return_visits_http%3A%2F%2Fgoogleid.khanacademy.org%2F106923455547952586722=1418086999.98161; snoozeNote_DonateNotification=7; fkey=1.0_0WVFcnbssrIRSw==_1418002092; gae_b_id=; _gat=1',
-          'Connection': ' keep-alive',
-          'Pragma': ' no-cache',
-          'Cache-Control': ' no-cache',
-          'Access-Control-Allow-Origin': '*'
-      },
-      //the url where you want to sent the userName and password to
-      url: url,
-      data: '{"text":"' + KA.userProfileData_.username + ' running MultiTool v' + version + '","topic_slug":"computer-programming"}',
-      async: false,
-      success: function() {
-      },
-      error: function() {
-        console.log("Error while posting collect information.");
-      }
+        var method = "POST";
+        var url = "https://www.khanacademy.org/api/internal/discussions/scratchpad/4684982804152320/comments?casing=camel&lang=en&_=1440374463375";
+        if (postedCollectAlready && postedCollectThisVersion) {
+            return;
+        } else if (postedCollectAlready && !postedCollectThisVersion) {
+            method = "PUT";
+            url = "https://www.khanacademy.org/api/internal/discussions/scratchpad/4684982804152320/comments/" + oldCollectID;
+        }
+        $.ajax({
+            type: method,
+            dataType: 'json',
+            headers: {
+                'Accept': ' application/json, text/javascript, *\/*; q=0.01',
+                'Accept-Language': ' en-US,en;q=0.5',
+                'Accept-Encoding': ' gzip, deflate',
+                'Content-Type': ' application/json; charset=UTF-8',
+                'X-KA-FKey': ' 1.0_0WVFcnbssrIRSw==_1418002092',
+                'X-Requested-With': ' XMLHttpRequest',
+                'Referer': 'https://www.khanacademy.org/computer-programming/new/pjs',
+                'Content-Length': ' 1140',
+                'Cookie': ' __utma=3422703.336972004.1403884371.1403902070.1403904116.3; __utmz=3422703.1403884371.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none); __utmv=3422703.|1=User%20Type=Logged%20In=1^2=User%20Points=136166=1; sailthru_hid=4b8f7adeb499caa26d47f80e585eec61526568688910a60103d70cf99ea395de16bf1a50e79f51405223d892; _ga=GA1.2.336972004.1403884371; sailthru_hid=4b8f7adeb499caa26d47f80e585eec61526568688910a60103d70cf9cea67b599e12b49945cb914b5b33c9f4; __qca=P0-449990055-1409427600374; mp_5f375bcfa7dc57184da63393e2af841c_mixpanel=%7B%22distinct_id%22%3A%20%22_gae_bingo_random%3A6-2qpzzhLcEtDidvTMgraAic7NRRZUq2CUo1dTnm%22%2C%22mp_name_tag%22%3A%20%22MarioMuddMook%22%2C%22%24initial_referrer%22%3A%20%22https%3A%2F%2Fwww.khanacademy.org%2Fprofile%2F_kag5zfmtoYW4tYWNhZGVteXJPCxIIVXNlckRhdGEiQXVzZXJfaWRfa2V5X2h0dHA6Ly9nb29nbGVpZC5raGFuYWNhZGVteS5vcmcvMTE3NTgwMjI3MDI5NDQ3MDI4MDE0DA%2F%22%2C%22%24initial_referring_domain%22%3A%20%22www.khanacademy.org%22%2C%22%24search_engine%22%3A%20%22google%22%7D; ki_t=1414630478786%3B1418078964708%3B1418088378667%3B27%3B1737; ki_r=; ki_s=129611%3A0.0.0.0.0%3B131503%3A0.0.0.0.0%3B131508%3A0.0.0.0.0%3B132319%3A0.0.0.0.0; return_visits_null=1416961078.08733; ki_u=5d8258f4-9ebe-9448-26f4-4ee4; KAID=YWc1emZtdG9ZVzR0WVdOaFpHVnRlWEpQQ3hJSVZYTmxja1JoZEdFaVFYVnpaWEpmYVdSZmEyVjVYMmgwZEhBNkx5OW5iMjluYkdWcFpDNXJhR0Z1WVdOaFpHVnRlUzV2Y21jdk1UQTJPVEl6TkRVMU5UUTNPVFV5TlRnMk56SXlEQQoyMDE0MzM4MDMwOTI0Ljc2ODMxMAoxCjdlOGU1MDJiNGRkZDQyZDYwNDQ4ZDM0NDMxNjUzODFkNzExZDhhN2Y2YjliMDAzNDIwM2VhYTE0NDhlOWQwZDI=; return_visits_http%3A%2F%2Fgoogleid.khanacademy.org%2F106923455547952586722=1418086999.98161; snoozeNote_DonateNotification=7; fkey=1.0_0WVFcnbssrIRSw==_1418002092; gae_b_id=; _gat=1',
+                'Connection': ' keep-alive',
+                'Pragma': ' no-cache',
+                'Cache-Control': ' no-cache',
+                'Access-Control-Allow-Origin': '*'
+            },
+            //the url where you want to sent the userName and password to
+            url: url,
+            data: '{"text":"' + KA.userProfileData_.username + ' running MultiTool v' + version + '","topic_slug":"computer-programming"}',
+            async: false,
+            success: function() {},
+            error: function() {
+                console.log("Error while posting collect information.");
+            }
+        });
+
     });
-    
-  });
 }


### PR DESCRIPTION
This PR cleans up the codebase of MultiTool. Some forgotten semicolons have been been put in along with quite a few other minor syntax mistakes fixed. All files have also been run through jsbeautifier, all hard tabs have been converted to soft tabs, and all CRLF line endings have been replaced with LF line endings. A setting in the .gitattributes file that was automatically converting line endings has also been deleted.
Thank you for your time.